### PR TITLE
add openfoam test case to db and minor tweaks to job api to talk to jm

### DIFF
--- a/routes/__init__.py
+++ b/routes/__init__.py
@@ -22,4 +22,4 @@ def setup_routes(app, api):
     api.add_resource(StatusApi, '/job/<int:job_id>/status')
 
     # Only while in development
-    api.add_resource(TestData, '/test')
+    api.add_resource(TestData, '/test/<int:test_id>')

--- a/routes/fake_routes.py
+++ b/routes/fake_routes.py
@@ -6,13 +6,17 @@ from flask_restful import Resource
 
 from tests.create_and_mint_case_using_stores import set_up_test_database
 
+from tests.openfoam_test_data import upload_dambreak_test
 
 class TestData(Resource):
     """
     Class to be used for generating fake data
     """
-    def post(self):
+    def post(self,test_id):
         """
         This just creates the default fake data
         """
-        set_up_test_database()
+        if test_id == 0:
+            set_up_test_database()
+        else:
+            upload_dambreak_test()

--- a/routes/job_routes.py
+++ b/routes/job_routes.py
@@ -127,13 +127,16 @@ class JobApi(Resource):
                                          'before starting a job'])
         params = {
             'fields_to_patch': job.field_list(),
-            'scripts': job.script_list()
+            'scripts': job.script_list(),
+            'username': job.user
         }
-        response = requests.post('{}/{}/start'.format(JOB_MANAGER_URL, job_id),
-                                 params)
+        print("PARAMS",params)
+        response = requests.post('{}/job/{}/start'.format(JOB_MANAGER_URL, job_id),
+                                 json=params)
         if response.status_code != 200:
+            return params
             return make_response(RequestStatus.FAILED,
-                                 errors=['Job Managed returned HTTP {}'
+                                 errors=['Job Manager returned HTTP {}'
                                          .format(response.status_code)])
 
         result = response.json
@@ -169,3 +172,14 @@ class StatusApi(Resource):
         job.status = status.value
         db.session.commit()
         return make_response()
+
+    def get(self, job_id:int):
+        """
+        get the job status from the job manager
+        """
+        
+        response = requests.get('{}/job/{}/status'.format(JOB_MANAGER_URL, job_id))
+        return response.json()
+
+    
+                                 

--- a/tests/openfoam_test_data.py
+++ b/tests/openfoam_test_data.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python
+
+"""
+create a Case corresponding to openfoam dambreak and store it in
+the db.
+"""
+
+from connection import init_database
+from connection.models import (db, Case, CaseField, Script,
+                               JobParameterTemplate, JobParameter, Job)
+
+from flask import Flask
+from flask_restful import Api
+
+def make_dambreak():
+    """
+    the openfoam dambreak case.
+    """
+    dambreak = Case(name="dambreak_test")
+
+    allrun_script = Script(name="Allrun",
+                         url="testopenfoamapi",
+                         parent_case = dambreak)
+    allclean_script = Script(name="Allclean",
+                           url="testopenfoamapi",
+                           parent_case = dambreak)
+    return dambreak
+
+
+def upload_dambreak_test():
+    """
+    upload test case and scripts to db
+    """
+    session = db.session
+    dambreak = make_dambreak()
+    session.add(dambreak)
+    session.commit()


### PR DESCRIPTION
a new fake_route test api to upload an empty case with some scripts (location and name on azure blob storage) to db.

Also some very minor tweaks to job start api endpoint to work with job-manager.