### PR TITLE
Endpoint authentication

### DIFF
--- a/app.py
+++ b/app.py
@@ -3,16 +3,13 @@
 The main entry point for this flask app
 """
 
-from json import load
 import os
-
 
 from flask import Flask
 from flask_cors import CORS
 from flask_restful import Api
 
 from connection import init_database, init_marshmallow
-import connection.constants as const
 from routes import setup_routes
 
 app = Flask(__name__)

--- a/app.py
+++ b/app.py
@@ -3,6 +3,7 @@
 The main entry point for this flask app
 """
 
+import os
 from json import load
 
 from flask import Flask
@@ -15,10 +16,9 @@ from routes import setup_routes
 
 app = Flask(__name__)
 
-with open('config.json') as json:
-    args = load(json)
-    app.config['SQLALCHEMY_DATABASE_URI'] = args['database_url']
-    const.JOB_MANAGER_URL = args['job_manager_url']
+config_mode = os.getenv('FLASK_CONFIGURATION', 'development')
+config_fname = "config.{}.json".format(config_mode.lower())
+app.config.from_json(config_fname)
 app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
 
 init_database(app)

--- a/app.py
+++ b/app.py
@@ -3,8 +3,9 @@
 The main entry point for this flask app
 """
 
-import os
 from json import load
+import os
+
 
 from flask import Flask
 from flask_cors import CORS

--- a/app.py
+++ b/app.py
@@ -18,7 +18,7 @@ from routes import setup_routes
 app = Flask(__name__)
 
 config_mode = os.getenv('FLASK_CONFIGURATION', 'development')
-config_fname = "config.{}.json".format(config_mode.lower())
+config_fname = 'config.{}.json'.format(config_mode.lower())
 app.config.from_json(config_fname)
 app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
 

--- a/config.development.json
+++ b/config.development.json
@@ -1,0 +1,5 @@
+{
+    "SQLALCHEMY_DATABASE_URI": "postgres://sg:sg@postgres/sg",
+    "JOB_MANAGER_URL": "http://job-manager:5001/job",
+    "AUTHENTICATION_URL": "http://auth:6000/auth/status"
+}

--- a/config.development.json
+++ b/config.development.json
@@ -1,5 +1,6 @@
 {
     "SQLALCHEMY_DATABASE_URI": "postgres://sg:sg@postgres/sg",
     "JOB_MANAGER_URL": "http://job-manager:5001/job",
-    "AUTHENTICATION_URL": "http://auth:6000/auth/status"
+    "AUTHENTICATION_URL": "http://auth:6000/auth/status",
+    "AUTHENTICATE_ROUTES": true
 }

--- a/config.json
+++ b/config.json
@@ -1,4 +1,0 @@
-{
-    "database_url": "postgres://sg:sg@postgres/sg",
-    "job_manager_url": "localhost:9000"
-}

--- a/connection/constants.py
+++ b/connection/constants.py
@@ -6,9 +6,6 @@ from enum import Enum
 
 from werkzeug.routing import BaseConverter
 
-JOB_MANAGER_URL = 'http://job-manager:5001/job'
-
-
 class JobStatus(Enum):
     """
     Job status enum. Variable must always be UPPERCASE.

--- a/connection/constants.py
+++ b/connection/constants.py
@@ -6,6 +6,7 @@ from enum import Enum
 
 from werkzeug.routing import BaseConverter
 
+
 class JobStatus(Enum):
     """
     Job status enum. Variable must always be UPPERCASE.

--- a/routes/authentication.py
+++ b/routes/authentication.py
@@ -3,13 +3,13 @@ Authentication functions for the routes
 """
 
 from functools import wraps
-from flask import request, Response, current_app
+
+from flask import current_app, request, Response
 import requests
 
 
 def token_required(f):
     """Checks whether token is valid or raises error 401."""
-
     @wraps(f)
     def decorated(*args, **kwargs):
         token_string = request.headers.get('Authorization')

--- a/routes/authentication.py
+++ b/routes/authentication.py
@@ -1,0 +1,33 @@
+"""
+Authentication functions for the routes
+"""
+
+from functools import wraps
+from flask import request, Response, current_app
+import requests
+
+
+def token_required(f):
+    """Checks whether token is valid or raises error 401."""
+
+    @wraps(f)
+    def decorated(*args, **kwargs):
+        token_string = request.headers.get('Authorization')
+
+        auth_url = current_app.config['AUTHENTICATION_URL']
+        use_authentication = current_app.config['AUTHENTICATE_ROUTES']
+
+        if not use_authentication:
+            # don't authenticate routes
+            return f(*args, **kwargs)
+        else:
+            # authenticate routes
+            r = requests.get(auth_url, headers={'Authorization': token_string})
+            if r.status_code == 200:
+                return f(*args, **kwargs)
+            else:
+                return Response('User not authenticated',
+                    401, {'WWW-Authenticate': 'Basic realm="Login Required"'})
+
+
+    return decorated

--- a/routes/authentication.py
+++ b/routes/authentication.py
@@ -26,8 +26,9 @@ def token_required(f):
             if r.status_code == 200:
                 return f(*args, **kwargs)
             else:
-                return Response('User not authenticated',
-                    401, {'WWW-Authenticate': 'Basic realm="Login Required"'})
-
+                return Response(
+                    'User not authenticated',
+                    401,
+                    {'WWW-Authenticate': 'Basic realm="Login Required"'})
 
     return decorated

--- a/routes/authentication.py
+++ b/routes/authentication.py
@@ -12,6 +12,7 @@ def token_required(f):
     """Checks whether token is valid or raises error 401."""
     @wraps(f)
     def decorated(*args, **kwargs):
+        """Return function for decorator"""
         token_string = request.headers.get('Authorization')
 
         auth_url = current_app.config['AUTHENTICATION_URL']

--- a/routes/case_routes.py
+++ b/routes/case_routes.py
@@ -12,7 +12,7 @@ from connection.schemas import CaseHeaderSchema, CaseSchema
 case_schema = CaseSchema()
 case_header_schema = CaseHeaderSchema()
 
-from .helpers import token_required
+from .authentication import token_required
 
 
 class CasesApi(Resource):
@@ -20,7 +20,7 @@ class CasesApi(Resource):
     Api for the list of all cases
     """
 
-    # @token_required
+    @token_required
     @use_kwargs(PaginationArgs())
     def get(self, page, per_page):
         """
@@ -43,7 +43,7 @@ class CaseApi(Resource):
     End point for dealing with a specific case
     """
 
-    # @token_required
+    @token_required
     def get(self, case_id: str):
         """
         Get all the details for a specific case

--- a/routes/case_routes.py
+++ b/routes/case_routes.py
@@ -8,7 +8,6 @@ from webargs.flaskparser import use_kwargs
 from connection.api_schemas import PaginationArgs
 from connection.models import Case
 from connection.schemas import CaseHeaderSchema, CaseSchema
-
 from .authentication import token_required
 
 case_schema = CaseSchema()

--- a/routes/case_routes.py
+++ b/routes/case_routes.py
@@ -12,12 +12,15 @@ from connection.schemas import CaseHeaderSchema, CaseSchema
 case_schema = CaseSchema()
 case_header_schema = CaseHeaderSchema()
 
+from .helpers import token_required
+
 
 class CasesApi(Resource):
     """
     Api for the list of all cases
     """
 
+    # @token_required
     @use_kwargs(PaginationArgs())
     def get(self, page, per_page):
         """
@@ -40,6 +43,7 @@ class CaseApi(Resource):
     End point for dealing with a specific case
     """
 
+    # @token_required
     def get(self, case_id: str):
         """
         Get all the details for a specific case

--- a/routes/case_routes.py
+++ b/routes/case_routes.py
@@ -9,10 +9,10 @@ from connection.api_schemas import PaginationArgs
 from connection.models import Case
 from connection.schemas import CaseHeaderSchema, CaseSchema
 
+from .authentication import token_required
+
 case_schema = CaseSchema()
 case_header_schema = CaseHeaderSchema()
-
-from .authentication import token_required
 
 
 class CasesApi(Resource):

--- a/routes/helpers.py
+++ b/routes/helpers.py
@@ -2,11 +2,7 @@
 Helper functions for the routes
 """
 
-from functools import wraps
 from typing import List
-
-from flask import current_app, request, Response
-import requests
 
 from connection.constants import RequestStatus
 
@@ -21,23 +17,3 @@ def make_response(response: RequestStatus=RequestStatus.SUCCESS,
         'data': messages,
         'errors': errors
     }
-
-
-def token_required(f):
-    """Checks whether token is valid or raises error 401."""
-    @wraps(f)
-    def decorated(*args, **kwargs):
-        token_string = request.headers.get('Authorization')
-
-        auth_url = current_app.config['AUTHENTICATION_URL']
-        r = requests.get(auth_url, headers={'Authorization': token_string})
-
-        if r.status_code == 200:
-            return f(*args, **kwargs)
-        else:
-            return Response(
-                'User not authenticated',
-                401,
-                {'WWW-Authenticate': 'Basic realm="Login Required"'})
-
-    return decorated

--- a/routes/helpers.py
+++ b/routes/helpers.py
@@ -3,11 +3,11 @@ Helper functions for the routes
 """
 
 from typing import List
-from connection.constants import RequestStatus
-
 from functools import wraps
+
 from flask import request, Response, current_app
 import requests
+from connection.constants import RequestStatus
 
 
 def make_response(response: RequestStatus=RequestStatus.SUCCESS,

--- a/routes/helpers.py
+++ b/routes/helpers.py
@@ -35,7 +35,9 @@ def token_required(f):
         if r.status_code == 200:
             return f(*args, **kwargs)
         else:
-            return Response('User not authenticated',
-                401, {'WWW-Authenticate': 'Basic realm="Login Required"'})
+            return Response(
+                'User not authenticated',
+                401,
+                {'WWW-Authenticate': 'Basic realm="Login Required"'})
 
     return decorated

--- a/routes/helpers.py
+++ b/routes/helpers.py
@@ -2,11 +2,12 @@
 Helper functions for the routes
 """
 
-from typing import List
 from functools import wraps
+from typing import List
 
-from flask import request, Response, current_app
+from flask import current_app, request, Response
 import requests
+
 from connection.constants import RequestStatus
 
 
@@ -24,7 +25,6 @@ def make_response(response: RequestStatus=RequestStatus.SUCCESS,
 
 def token_required(f):
     """Checks whether token is valid or raises error 401."""
-
     @wraps(f)
     def decorated(*args, **kwargs):
         token_string = request.headers.get('Authorization')

--- a/routes/job_routes.py
+++ b/routes/job_routes.py
@@ -5,6 +5,8 @@ import json
 from uuid import uuid4
 
 from flask_restful import abort, Resource
+from flask import current_app
+
 import requests
 from sqlalchemy.exc import IntegrityError
 from webargs import missing
@@ -12,7 +14,7 @@ from webargs.flaskparser import use_kwargs
 
 from connection.api_schemas import (JobArgs, JobPatchArgs, OutputArgs,
                                     PaginationArgs, StatusPatchSchema)
-from connection.constants import JOB_MANAGER_URL, JobStatus, RequestStatus
+from connection.constants import JobStatus, RequestStatus
 from connection.models import db, Job, Output
 from connection.schemas import JobHeaderSchema, JobSchema, OutputSchema
 from .helpers import make_response
@@ -138,6 +140,7 @@ class JobApi(Resource):
             'scripts': job.script_list(),
             'username': job.user
         }
+        JOB_MANAGER_URL = current_app.config['JOB_MANAGER_URL']
         response = requests.post('{}/{}/start'.format(JOB_MANAGER_URL, job_id),
                                  json=params)
         if response.status_code != 200:

--- a/routes/job_routes.py
+++ b/routes/job_routes.py
@@ -19,6 +19,8 @@ from connection.models import db, Job, Output
 from connection.schemas import JobHeaderSchema, JobSchema, OutputSchema
 from .helpers import make_response
 
+from .authentication import token_required
+
 job_header_schema = JobHeaderSchema()
 job_schema = JobSchema()
 output_schema = OutputSchema()
@@ -29,6 +31,7 @@ class JobsApi(Resource):
     Endpoint for dealing with the list of jobs
     """
 
+    @token_required
     @use_kwargs(JobArgs(), locations=('json',))
     def post(self, case_id, name, author):
         """
@@ -47,6 +50,7 @@ class JobsApi(Resource):
                   message='Sorry, these parameters have already been used')
         return {'job_id': new_job.id}
 
+    @token_required
     @use_kwargs(PaginationArgs())
     def get(self, page, per_page):
         """
@@ -62,6 +66,7 @@ class JobApi(Resource):
     Endpoint for dealing with a specific job
     """
 
+    @token_required
     def get(self, job_id):
         """
         Get the specified job
@@ -78,6 +83,7 @@ class JobApi(Resource):
             abort(404, message='Sorry, jobs {} not found'.format(job_id))
             return None
 
+    @token_required
     @use_kwargs(JobPatchArgs())
     def patch(self, job_id, name, description, values):
         """
@@ -121,6 +127,7 @@ class JobApi(Resource):
             'errors': error_log
         }
 
+    @token_required
     def post(self, job_id):
         """
         Start the given job if it isn't started yet
@@ -200,6 +207,7 @@ class OutputApi(Resource):
     returned to the frontend.
     """
 
+    @token_required
     @use_kwargs(OutputArgs())
     def post(self, job_id, output_type, destination_path):
         """
@@ -214,6 +222,7 @@ class OutputApi(Resource):
         job.outputs.append(output)
         db.session.commit()
 
+    @token_required
     def get(self, job_id):
         """
         When the user wants to download an output, need to get a token or

--- a/routes/job_routes.py
+++ b/routes/job_routes.py
@@ -4,9 +4,8 @@ Defintions of routes for the app
 import json
 from uuid import uuid4
 
-from flask_restful import abort, Resource
 from flask import current_app
-
+from flask_restful import abort, Resource
 import requests
 from sqlalchemy.exc import IntegrityError
 from webargs import missing
@@ -17,9 +16,8 @@ from connection.api_schemas import (JobArgs, JobPatchArgs, OutputArgs,
 from connection.constants import JobStatus, RequestStatus
 from connection.models import db, Job, Output
 from connection.schemas import JobHeaderSchema, JobSchema, OutputSchema
-from .helpers import make_response
-
 from .authentication import token_required
+from .helpers import make_response
 
 job_header_schema = JobHeaderSchema()
 job_schema = JobSchema()

--- a/routes/job_routes.py
+++ b/routes/job_routes.py
@@ -228,6 +228,7 @@ class OutputApi(Resource):
         When the user wants to download an output, need to get a token or
         similar from the job manager to get the actual URL.
         """
+        JOB_MANAGER_URL = current_app.config['JOB_MANAGER_URL']
         r = requests.get('{}/{}/output'.format(JOB_MANAGER_URL, job_id))
         if r.status_code != 200:
             abort(404, message='Unable to get output for {}'.format(job_id))

--- a/tests/config.testing.json
+++ b/tests/config.testing.json
@@ -1,5 +1,6 @@
 {
     "SQLALCHEMY_DATABASE_URI": "sqlite://",
     "JOB_MANAGER_URL": "http://job-manager:5001/job",
-    "AUTHENTICATION_URL": "http://auth:6000/auth/status"
+    "AUTHENTICATION_URL": "http://auth:6000/auth/status",
+    "AUTHENTICATE_ROUTES": false
 }

--- a/tests/config.testing.json
+++ b/tests/config.testing.json
@@ -1,0 +1,5 @@
+{
+    "SQLALCHEMY_DATABASE_URI": "sqlite://",
+    "JOB_MANAGER_URL": "http://job-manager:5001/job",
+    "AUTHENTICATION_URL": "http://auth:6000/auth/status"
+}

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -21,8 +21,9 @@ def demo_app():
     """
     app = Flask(__name__)
 
-    app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite://'
+    app.config.from_json('config.testing.json')
     app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
+
     app.testing = True
 
     init_database(app)

--- a/tests/test_job_running.py
+++ b/tests/test_job_running.py
@@ -6,7 +6,7 @@ Tests for the job starting api
 
 from requests_mock import Mocker
 
-from connection.constants import JOB_MANAGER_URL, JobStatus, RequestStatus
+from connection.constants import JobStatus, RequestStatus
 from connection.models import Job
 from routes import JobApi, JobsApi, StatusApi
 from .decorators import request_context
@@ -30,7 +30,7 @@ def test_start_job_without_values(demo_app, test_job_id_no_values):
     Test that you can't start a job with unset values
     """
     with Mocker() as m:
-        m.post('{}/{}/start'.format(JOB_MANAGER_URL, test_job_id_no_values),
+        m.post('{}/{}/start'.format(demo_app.config['JOB_MANAGER_URL'], test_job_id_no_values),
                json='data')
         result = JobApi().dispatch_request(test_job_id_no_values)
     assert len(result['errors']) > 0
@@ -45,7 +45,7 @@ def test_start_job(demo_app, test_job_id):
     Test that you can start a job
     """
     with Mocker() as m:
-        m.post('{}/{}/start'.format(JOB_MANAGER_URL, test_job_id),
+        m.post('{}/{}/start'.format(demo_app.config['JOB_MANAGER_URL'], test_job_id),
                json='data')
         result = JobApi().dispatch_request(test_job_id)
     assert result['status'] == RequestStatus.SUCCESS.value

--- a/tests/test_job_running.py
+++ b/tests/test_job_running.py
@@ -30,8 +30,10 @@ def test_start_job_without_values(demo_app, test_job_id_no_values):
     Test that you can't start a job with unset values
     """
     with Mocker() as m:
-        m.post('{}/{}/start'.format(demo_app.config['JOB_MANAGER_URL'], test_job_id_no_values),
-               json='data')
+        start_url = '{}/{}/start'.format(
+            demo_app.config['JOB_MANAGER_URL'],
+            test_job_id_no_values)
+        m.post(start_url, json='data')
         result = JobApi().dispatch_request(test_job_id_no_values)
     assert len(result['errors']) > 0
     assert result['status'] == RequestStatus.FAILED.value
@@ -45,8 +47,9 @@ def test_start_job(demo_app, test_job_id):
     Test that you can start a job
     """
     with Mocker() as m:
-        m.post('{}/{}/start'.format(demo_app.config['JOB_MANAGER_URL'], test_job_id),
-               json='data')
+        start_url = '{}/{}/start'.format(
+            demo_app.config['JOB_MANAGER_URL'], test_job_id)
+        m.post(start_url, json='data')
         result = JobApi().dispatch_request(test_job_id)
     assert result['status'] == RequestStatus.SUCCESS.value
     assert Job.query.get(test_job_id).status == JobStatus.QUEUED.value


### PR DESCRIPTION
### Authentication

Adds `@token_required` decorator for authenticating endpoints.

Authentication is achieved by checking the validity of the JWT token passed with each http request arriving from the frontend.

Configurable parameters are:

```
    "AUTHENTICATION_URL": "http://auth:6000/auth/status",
    "AUTHENTICATE_ROUTES": true
```

We set `AUTHENTICATE_ROUTES` to `false` when undertaking unit tests.


### Configuration

Middleware configuration is now via json files:

* `config.development.json`
* `tests/config.testing.json`

(Future addition will be `config.production.json`. Also suggest moving `tests/config.testing.json` to top-level `config.testing.json`.)




