### PR TITLE
Endpoint authentication

### DIFF
--- a/config.development.json
+++ b/config.development.json
@@ -2,5 +2,5 @@
     "SQLALCHEMY_DATABASE_URI": "postgres://sg:sg@postgres/sg",
     "JOB_MANAGER_URL": "http://job-manager:5001/job",
     "AUTHENTICATION_URL": "http://auth:5050/auth/status",
-    "AUTHENTICATE_ROUTES": false
+    "AUTHENTICATE_ROUTES": true
 }

--- a/routes/fake_routes.py
+++ b/routes/fake_routes.py
@@ -3,7 +3,7 @@ Make some fake routes for testing purposes
 """
 
 from flask_restful import Resource
-from tests.create_and_mint_case_using_stores import set_up_test_database
+# from tests.create_and_mint_case_using_stores import set_up_test_database
 from tests.create_cavity_case import set_up_cavity_testdata
 from tests.create_damBreak_case import set_up_dambreak_testdata
 

--- a/routes/fake_routes.py
+++ b/routes/fake_routes.py
@@ -17,6 +17,6 @@ class TestData(Resource):
         """
         Create the default fake data
         """
-        set_up_test_database()
+        # set_up_test_database()
         set_up_dambreak_testdata()
         set_up_cavity_testdata()

--- a/routes/job_routes.py
+++ b/routes/job_routes.py
@@ -205,7 +205,6 @@ class OutputApi(Resource):
     returned to the frontend.
     """
 
-    @token_required
     @use_kwargs(OutputArgs())
     def post(self, job_id, output_type, destination_path):
         """


### PR DESCRIPTION
* Allow job manager to access `OutputApi()` POST without token
* Populate openfoam test cases when calling `/test` endpoint (i.e. deactivate `set_up_test_database()`)
* Turn on development authentication by default
