### PR TITLE
Field component attribute

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,6 @@ __pycache__/
 
 # Test database
 test.db
+
+# Configuration
+config.development.json

--- a/app.py
+++ b/app.py
@@ -9,6 +9,7 @@ from time import sleep
 from flask import Flask
 from flask_cors import CORS
 from flask_restful import Api
+from sqlalchemy.exc import OperationalError
 
 from connection import init_database, init_marshmallow
 from routes import set_up_routes
@@ -26,7 +27,7 @@ while not db_loaded:
     try:
         db_loaded = True
         init_database(app)
-    except Exception as e:
+    except OperationalError as e:
         db_loaded = False
         logger.error(e)
         sleep(3)

--- a/config.example.json
+++ b/config.example.json
@@ -2,5 +2,5 @@
     "SQLALCHEMY_DATABASE_URI": "postgres://sg:sg@postgres/sg",
     "JOB_MANAGER_URL": "http://job-manager:5001/job",
     "AUTHENTICATION_URL": "http://auth:5050/auth/status",
-    "AUTHENTICATE_ROUTES": true
+    "AUTHENTICATE_ROUTES": false
 }

--- a/connection/api_schemas.py
+++ b/connection/api_schemas.py
@@ -16,7 +16,7 @@ class JobArgs(ma.Schema):
     Class to read in arguments to create a new job
     """
 
-    class Meta(object):
+    class Meta:
         """
         Ensure that it can only take the defined arguments
         """
@@ -42,7 +42,7 @@ class JobArgumentArgs(ma.Schema):
     Class to read in the arguments for a single Job argument value
     """
 
-    class Meta(object):
+    class Meta:
         """
         Ensure that other fields are not provided
         """
@@ -79,7 +79,7 @@ class JobPatchArgs(ma.Schema):
     Read in the arguments for patching a job
     """
 
-    class Meta(object):
+    class Meta:
         """
         Ensure that other fields are not provided
         """
@@ -104,7 +104,7 @@ class PaginationArgs(ma.Schema):
     Read in arguments for paginating
     """
 
-    class Meta(object):
+    class Meta:
         """
         Ensure that other fields are not provided
         """
@@ -128,7 +128,7 @@ class StatusPatchSchema(ma.Schema):
     Read in arguments for setting a status value
     """
 
-    class Meta(object):
+    class Meta:
         """
         Ensure that other fields are not provided
         """
@@ -152,7 +152,7 @@ class OutputArgs(ma.Schema):
     Check read-in arguments for creating a job Output.
     """
 
-    class Meta(object):
+    class Meta:
         """
         Ensure that it can only take the defined arguments
         """

--- a/connection/models.py
+++ b/connection/models.py
@@ -265,7 +265,7 @@ class Job(Base):
         """
         Check to make sure the job has all of it's required values set
         """
-        set_values = set([v.name for v in self.values])
+        set_values = set(v.name for v in self.values)
         required_values = self.parent_case.required_values()
         return len(required_values - set_values) == 0
 

--- a/connection/models.py
+++ b/connection/models.py
@@ -91,6 +91,7 @@ class CaseField(Base):
     case_id = db.Column(db.Integer, db.ForeignKey('case.id'),
                         nullable=True)
     name = db.Column(db.String, nullable=False)
+    component = db.Column(db.String, nullable=True)
     parent_id = db.Column(db.Integer,
                           db.ForeignKey('case_field.id'),
                           nullable=True)
@@ -106,7 +107,7 @@ class CaseField(Base):
         Create a deep clone
         """
         new_case_field = CaseField(
-            name=self.name)
+            name=self.name, component=self.component)
         for child in self.child_fields:
             new_case_field.child_fields.append(child.deep_copy())
         for spec in self.specs:

--- a/connection/schemas.py
+++ b/connection/schemas.py
@@ -46,7 +46,7 @@ class CaseFieldSchema(ma.ModelSchema):
         """
 
         model = CaseField
-        fields = ('name', 'child_fields', 'specs')
+        fields = ('name', 'child_fields', 'specs', 'component')
     child_fields = ma.Nested('self', many=True)
     specs = ma.List(ma.Nested('ParamSpecSchema'))
 

--- a/readme.md
+++ b/readme.md
@@ -99,6 +99,7 @@ that may be helpful:
     with an SQL keyword, you must wrap the table name in `"`
     ```sql
     SELECT * FROM "Case";
+    ```
 
 * Delete all tables:
     ```sql
@@ -127,7 +128,7 @@ It supports the following query args:
     The first page is 1.
     If you ask for a page that does not exist (i.e off the end) you will get an empty list.
 * `per_page` (optional, default=10) gives the number of results per page to return.
-    
+  
 No information about whether the next page exists is returned. 
 This is because I am expecting this to be used as part of an
 infinite scrolling system, where there is no explicit display to the user to ask for more 
@@ -209,7 +210,7 @@ It supports the following query args:
     The first page is 1.
     If you ask for a page that does not exist (i.e off the end) you will get an empty list.
 * `per_page` (optional, default=10) gives the number of results per page to return.
-    
+  
 No information about whether the next page exists is returned. 
 This is because I am expecting this to be used as part of an
 infinite scrolling system, where there is no explicit display to the user to ask for more 

--- a/tests/create_case_store.py
+++ b/tests/create_case_store.py
@@ -77,9 +77,12 @@ def make_phases():
     phase_store = Case(name='phases', visible=False)
     # phase_A (e.g. water)
     phase_A = CaseField(name='phase_A',
-                        parent_case=phase_store)
+                        parent_case=phase_store,
+                        component='heading')
 
-    phase_A_density = CaseField(name='density', parent_field=phase_A)
+    phase_A_density = CaseField(name='density',
+                                parent_field=phase_A,
+                                component='slider')
     ParameterSpec(name='min', value='1',
                   parent_casefield=phase_A_density)
     ParameterSpec(name='max', value='2000',
@@ -89,7 +92,9 @@ def make_phases():
     ParameterSpec(name='units', value='kg/m^3',
                   parent_casefield=phase_A_density)
 
-    phase_A_viscosity = CaseField(name='viscosity', parent_field=phase_A)
+    phase_A_viscosity = CaseField(name='viscosity',
+                                  parent_field=phase_A,
+                                  component='slider')
     ParameterSpec(name='min', value='0.000001',
                   parent_casefield=phase_A_viscosity)
     ParameterSpec(name='max', value='0.0001',
@@ -102,7 +107,8 @@ def make_phases():
                   parent_casefield=phase_A_viscosity)
 
     phase_A_surface_tension = CaseField(name='surface_tension',
-                                        parent_field=phase_A)
+                                        parent_field=phase_A,
+                                        component='slider')
     ParameterSpec(name='min', value='0.01',
                   parent_casefield=phase_A_surface_tension)
     ParameterSpec(name='max', value='0.1',
@@ -116,9 +122,12 @@ def make_phases():
 
     # phase_B (e.g. air)
     phase_B = CaseField(name='phase_B',
-                        parent_case=phase_store)
+                        parent_case=phase_store,
+                        component='heading')
 
-    phase_B_density = CaseField(name='density', parent_field=phase_B)
+    phase_B_density = CaseField(name='density',
+                                parent_field=phase_B,
+                                component='slider')
     ParameterSpec(name='min', value='1',
                   parent_casefield=phase_B_density)
     ParameterSpec(name='max', value='2000',
@@ -128,7 +137,9 @@ def make_phases():
     ParameterSpec(name='units', value='kg/m^3',
                   parent_casefield=phase_B_density)
 
-    phase_B_viscosity = CaseField(name='viscosity', parent_field=phase_B)
+    phase_B_viscosity = CaseField(name='viscosity',
+                                  parent_field=phase_B,
+                                  component='slider')
     ParameterSpec(name='min', value='0.000001',
                   parent_casefield=phase_B_viscosity)
     ParameterSpec(name='max', value='0.0001',

--- a/tests/create_cavity_case.py
+++ b/tests/create_cavity_case.py
@@ -63,8 +63,9 @@ def set_up_cavity_testdata():
                   visible=True)
 
     fluid = CaseField(name='fluid', parent_case=cavity)
-    kinematic_viscosity = CaseField(
-        name='kinematic_viscosity', parent_field=fluid)
+    kinematic_viscosity = CaseField(name='kinematic_viscosity',
+                                    parent_field=fluid,
+                                    component='slider')
     ParameterSpec(name='min', value='0.000001',
                   parent_casefield=kinematic_viscosity)
     ParameterSpec(name='max', value='0.0001',
@@ -77,7 +78,9 @@ def set_up_cavity_testdata():
                   parent_casefield=kinematic_viscosity)
 
     lid = CaseField(name='lid', parent_case=cavity)
-    wall_velocity = CaseField(name='wall_velocity', parent_field=lid)
+    wall_velocity = CaseField(name='wall_velocity',
+                              parent_field=lid,
+                              component='slider')
     ParameterSpec(name='min', value='0.1',
                   parent_casefield=wall_velocity)
     ParameterSpec(name='max', value='2.0',


### PR DESCRIPTION
Add "component" attribute on each field. The attribute is used to specify the type of component rendered in the front end, for example:

* `"component": "slider" `
* `"component": "heading" `


An example JSON serialisation of a field with the component attribute is

```json
{
    "child_fields": [],
    "component": "slider",
    "name": "wall_velocity",
    "specs": [
        {
            "id": 59,
            "name": "min",
            "value": "0.1"
        },
        {
            "id": 60,
            "name": "max",
            "value": "2.0"
        },
        {
            "id": 61,
            "name": "step",
            "value": "0.01"
        },
        {
            "id": 62,
            "name": "default",
            "value": "0.5"
        },
        {
            "id": 63,
            "name": "units",
            "value": "m/s"
        }
    ]
}
```