### PR TITLE
fix: Add metrics to cavity script

### DIFF
--- a/tests/create_cavity_case.py
+++ b/tests/create_cavity_case.py
@@ -68,11 +68,11 @@ def set_up_cavity_testdata():
     kinematic_viscosity = CaseField(
         name="kinematic_viscosity", parent_field=fluid, component="slider"
     )
-    ParameterSpec(name="min", value="0.000001", parent_casefield=kinematic_viscosity)
-    ParameterSpec(name="max", value="0.0001", parent_casefield=kinematic_viscosity)
-    ParameterSpec(name="step", value="0.000001", parent_casefield=kinematic_viscosity)
-    ParameterSpec(name="default", value="0.00001", parent_casefield=kinematic_viscosity)
-    ParameterSpec(name="units", value="m/s^2", parent_casefield=kinematic_viscosity)
+    ParameterSpec(name="min", value="0.001", parent_casefield=kinematic_viscosity)
+    ParameterSpec(name="max", value="1.0", parent_casefield=kinematic_viscosity)
+    ParameterSpec(name="step", value="0.001", parent_casefield=kinematic_viscosity)
+    ParameterSpec(name="default", value="0.01", parent_casefield=kinematic_viscosity)
+    ParameterSpec(name="units", value="m^2/s", parent_casefield=kinematic_viscosity)
 
     lid = CaseField(name="lid", parent_case=cavity)
     wall_velocity = CaseField(

--- a/tests/resources/cavity/Simulate/metrics.py
+++ b/tests/resources/cavity/Simulate/metrics.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python
+
+# Example output
+# output = {
+#     "labels": ["Time"],
+#     "names": ["time"],
+#     "units": ["s"],
+#     "metrics": {
+#         "time": [0.00119048, 0.00258503, 0.00422003, 0.00612753, 0.00832115, 0.0109261]
+#     },
+# }
+
+import subprocess
+
+import json
+import numpy as np
+
+subprocess.call("foamLog -n -quiet log.icoFoam", shell=True)
+
+selection_list = [
+    {"fpath": "logs/Time_0", "label": "Time", "name": "time", "units": "s"},
+    {
+        "fpath": "logs/CourantMax_0",
+        "label": "Courant Max",
+        "name": "courantMax_0",
+        "units": "",
+    },
+]
+
+output = {"labels": [], "names": [], "units": [], "metrics": {}}
+for selection in selection_list:
+    fpath = selection["fpath"]
+    label = selection["label"]
+    name = selection["name"]
+    units = selection["units"]
+
+    data = np.loadtxt(fpath).tolist()
+    output["metrics"][name] = data
+    output["labels"].append(label)
+    output["names"].append(name)
+    output["units"].append(units)
+
+
+with open("metrics.json", "w") as f:
+    json.dump(output, f)

--- a/tests/resources/cavity/Simulate/metrics.sh
+++ b/tests/resources/cavity/Simulate/metrics.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+
+echo "INFO: Start metrics"
+
+set -o xtrace
+
+SIMULATE="Simulate"
+STATE="$SIMULATE/state"
+CONFIG="$STATE/store.json"
+JOB_ID=$(cat $STATE/job_id)
+
+FNAME="metrics.json"
+
+JOB_STORAGE_TOKEN=$(cat $CONFIG | jq -r '.data.token')
+ACCOUNT=$(cat $CONFIG | jq -r '.data.account')
+CONTAINER=$(cat $CONFIG | jq -r '.data.container')
+BLOB="$JOB_ID/$FNAME"
+
+# LOCKDIR='.lock_storage_sync'
+
+# mkdir $LOCKDIR  || {
+#     echo "ERROR: lock directory exists. exiting"
+#     exit 1
+# }
+
+# # remove lock directory
+# trap "rmdir $LOCKDIR" EXIT INT KILL TERM
+
+# transfer files to cloud storage
+CMD="az storage blob upload \
+--container-name $CONTAINER \
+--file $FNAME \
+--account-name $ACCOUNT \
+--sas-token '$JOB_STORAGE_TOKEN' \
+--name '$BLOB' "
+
+
+
+
+# HACK wrap command in bash (otherwise not working)
+echo $CMD > $STATE/metrics_cmd.sh
+bash $STATE/metrics_cmd.sh | tee $STATE/log.metrics_cmd
+
+echo "INFO: End metrics"

--- a/tests/resources/cavity/Simulate/outputs.py
+++ b/tests/resources/cavity/Simulate/outputs.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python
+
+import requests
+import json
+
+fname = "Simulate/state/job_id"
+with open(fname, "r") as f:
+    job_id = f.readline()
+
+url = f"http://manager:5001/job/{job_id}/output"
+
+payload = {
+    "outputs": [
+        {
+            "destination": f"https://simulate.blob.core.windows.net/openfoam-test-output/{job_id}/metrics.json",
+            "type": "metrics",
+            "name": "metrics",
+            "label": "Metrics (json)",
+            "filename": "metrics.json",
+        },
+        {
+            "destination": f"https://simulate.blob.core.windows.net/openfoam-test-output/{job_id}/output.zip",
+            "type": "zip",
+            "name": "output",
+            "label": "Output (zip)",
+            "filename": "output.zip",
+        },
+    ]
+}
+
+headers = {
+    "Content-Type": "application/json",
+    # 'Authorization': "Bearer fooToken",
+}
+
+response = requests.request("POST", url, data=json.dumps(payload), headers=headers)
+
+print(response.text)

--- a/tests/resources/cavity/Simulate/store.sh
+++ b/tests/resources/cavity/Simulate/store.sh
@@ -6,14 +6,13 @@ set -o xtrace
 
 SIMULATE="Simulate"
 STATE="$SIMULATE/state"
-CONFIG="$STATE/store.json"
+CONFIG="$STATE/store.json"  # example: d33aa355-af2a-4a80-b9be-63d63cc836d4
+
 JOB_ID=$(cat $STATE/job_id)
-
-
 JOB_STORAGE_TOKEN=$(cat $CONFIG | jq -r '.data.token')
-ACCOUNT=$(cat $CONFIG | jq -r '.data.account')
-CONTAINER=$(cat $CONFIG | jq -r '.data.container')
-BLOB=$(cat $CONFIG | jq -r '.data.blob')
+ACCOUNT=$(cat $CONFIG | jq -r '.data.account')  # example: simulate
+CONTAINER=$(cat $CONFIG | jq -r '.data.container')  # example: openfoam-test-output
+BLOB=$(cat $CONFIG | jq -r '.data.blob')  # example: d33aa355-af2a-4a80-b9be-63d63cc836d4/output.zip
 
 LOCKDIR='.lock_storage_sync'
 


### PR DESCRIPTION
* Adds metrics output for openfoam cavity case

Addresses: https://github.com/alan-turing-institute/simulate/issues/89